### PR TITLE
fix weapon main stat condition

### DIFF
--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -340,7 +340,7 @@ export const useStats = ({
       
       if (weapon && weaponStats) {
         const percentStatName = `${displayStat}%`;
-        if (weapon.main_stat === percentStatName) {
+        if (weapon.main_stat === displayStat) {
           percent += weaponStats.scaledMainStat;
         }
         if (weapon.passive === percentStatName) {


### PR DESCRIPTION
weapon main stats, such as ATK/HP/DEF, don't work

before fix:
![2025-02-06 16 22 48](https://github.com/user-attachments/assets/0876bf74-f5c4-4468-b515-1c6759b779f6)

stats in game:
![image](https://github.com/user-attachments/assets/cf7ac57e-91c1-485e-a56d-3a0eb4c955cd)

after fix:
![2025-02-06 16 23 48](https://github.com/user-attachments/assets/c8863f8a-897a-4f6f-bcbb-611fa1b8c84e)

